### PR TITLE
Added Smoke Binary Sensor Support (needs to be tested)

### DIFF
--- a/HA parent.groovy
+++ b/HA parent.groovy
@@ -50,6 +50,7 @@
 *                                      (Manually updating the device type to the corresponding one is required in Hubitat. Only statuses of level and switch are shown in Hubitat.)
 * 0.1.27 2021-04-11 Yves Mercier       Added option for secure connection
 * 0.1.28 2021-04-14 Dan Ogorchock      Improved Fan Device handling
+* 0.1.29 2021-04-17 Dan Ogorchock      Added support for Smoke Detector Binary Sensor
 *
 * Thank you(s):
 */
@@ -246,6 +247,7 @@ def translateDevices(device_class, newVals, friendly)
             opening: [type: "Generic Component Contact Sensor",         event: [[name: "contact", value: newVals[0] == "on" ? "open":"closed", descriptionText:"${friendly} is updated"]]],
             presence: [type: "Generic Component Presence Sensor",       event: [[name: "presence", value: newVals[0] == "on" ? "present":"not present", descriptionText:"${friendly} is updated"]]],
             pressure: [type: "Generic Component Pressure Sensor",       event: [[name: "pressure", value: newVals[0], descriptionText:"${friendly} pressure is ${newVals[0]}"]], namespace: "community"],
+            smoke: [type: "Generic Component Smoke Detector",           event: [[name: "smoke", value: newVals[0] == "on" ? "detected":"clear", descriptionText:"${friendly} is updated"]]],
             switch: [type: "Generic Component Switch",                  event: [[name: "switch", value: newVals[0], descriptionText:"${friendly} was turn ${newVals[0]}"]]],
             temperature: [type: "Generic Component Temperature Sensor", event: [[name: "temperature", value: newVals[0], descriptionText:"${friendly} temperature is ${newVals[0]}"]]],
             voltage: [type: "Generic Component Voltage Sensor",         event: [[name: "voltage", value: newVals[0], descriptionText:"${friendly} voltage is ${newVals[0]}"]]],


### PR DESCRIPTION
Per a user requested, added support for the Home Assistant 'smoke' Binary Sensor.  This needs to be tested as I do not have any smoke detectors on my instance of Hass.