### PR TITLE
Improved Climate Device Integration

### DIFF
--- a/HA parent.groovy
+++ b/HA parent.groovy
@@ -244,11 +244,17 @@ def parse(String description) {
                 def fan_mode = response?.event?.data?.new_state?.attributes?.fan_mode
                 def preset_mode = response?.event?.data?.new_state?.attributes?.preset_mode
                 def swing_mode = response?.event?.data?.new_state?.attributes?.swing_mode
+				def hvac_action = response?.event?.data?.new_state?.attributes?.hvac_action
+				def target_temp_high = response?.event?.data?.new_state?.attributes?.target_temp_high
+				def target_temp_low = response?.event?.data?.new_state?.attributes?.target_temp_low
                 newVals += current_temperature
                 newVals += target_temperature
                 newVals += fan_mode
                 newVals += preset_mode
                 newVals += swing_mode
+				newVals += hvac_action
+				newVals += target_temp_high
+				newVals += target_temp_low
                 mapping = translateDevices(domain, newVals, friendly, origin)
                 if (mapping) updateChildDevice(mapping, entity, friendly) 
                 break
@@ -287,7 +293,7 @@ def translateDevices(device_class, newVals, friendly, origin)
             device_tracker: [type: "Generic Component Presence Sensor", event: [[name: "presence", value: newVals[0] == "home" ? "present":"not present", descriptionText:"${friendly} is updated"]], namespace: "community"],
             cover: [type: "Generic Component Garage Door Control",      event: [[name: "door", value: newVals[0] ?: "unknown", type: origin, descriptionText:"${friendly} was turn ${newVals[0]} [${origin}]"]], namespace: "community"],
             lock: [type: "Generic Component Lock",                      event: [[name: "lock", value: newVals[0] ?: "unknown", type: origin, descriptionText:"${friendly} was turn ${newVals[0]} [${origin}]"]]],
-            climate: [type: "Generic Component Thermostat",             event: [[name: "thermostatMode", value: newVals[0], descriptionText: "${friendly} is set to ${newVals[0]}"],[name: "temperature", value: newVals[1], descriptionText: "${friendly}'s current temperature is ${newVals[1]} degree"],[name: "coolingSetpoint", value: newVals[2], descriptionText: "${friendly}'s cooling temperature is set to ${newVals[2]} degree"],[name: "heatingSetpoint", value: newVals[2], descriptionText: "${friendly}'s heating temperature is set to ${newVals[2]} degree"],[name: "thermostatFanMode", value: newVals[3], descriptionText: "${friendly}'s fan speed is set to ${newVals[3]}"],[name: "presetMode", value: newVals[4], descriptionText: "${friendly}'s preset mode is set to ${newVals[4]}"],[name: "swingMode", value: newVals[5], descriptionText: "${friendly}'s swing mode is set to ${newVals[5]}"],[name: "thermostatSetpoint", value: newVals[2], descriptionText: "${friendly}'s temperature is set to ${newVals[2]} degree"]]]
+            climate: [type: "Generic Component Thermostat",             event: [[name: "thermostatMode", value: newVals[0], descriptionText: "${friendly} is set to ${newVals[0]}"],[name: "temperature", value: newVals[1], descriptionText: "${friendly}'s current temperature is ${newVals[1]} degree"],[name: "coolingSetpoint", value: newVals[2], descriptionText: "${friendly}'s cooling temperature is set to ${newVals[2]} degree"],[name: "heatingSetpoint", value: newVals[2], descriptionText: "${friendly}'s heating temperature is set to ${newVals[2]} degree"],[name: "thermostatFanMode", value: newVals[3], descriptionText: "${friendly}'s fan speed is set to ${newVals[3]}"],[name: "presetMode", value: newVals[4], descriptionText: "${friendly}'s preset mode is set to ${newVals[4]}"],[name: "swingMode", value: newVals[5], descriptionText: "${friendly}'s swing mode is set to ${newVals[5]}"],[name: "thermostatSetpoint", value: newVals[2], descriptionText: "${friendly}'s temperature is set to ${newVals[2]} degree"],[name: "thermostatOperatingState", value: newVals[6], descriptionText: "${friendly} is ${newVals[6]}"],[name: "coolingSetpoint", value: newVals[7], descriptionText: "${friendly}'s cooling temperature is set to ${newVals[7]} degrees"],[name: "heatingSetpoint", value: newVals[8], descriptionText: "${friendly}'s heating temperature is set to ${newVals[8]} degrees"]]]
         ]
 
     return mapping[device_class]


### PR DESCRIPTION
Added HA attributes target_temp_high and target_temp_low as coolingSetpoint and heatingSetpoint attributes to be reported by the HE Generic Component Thermostat driver.  This code adds read-only support for these values.  No support for the commands "Set [Cooling/Heating] Setpoint" was added.