### PR TITLE
Add new 'menu: "Integrations"' field to the App definition section

### DIFF
--- a/haDeviceBridgeConfiguration.groovy
+++ b/haDeviceBridgeConfiguration.groovy
@@ -40,6 +40,7 @@
 * 2.15       2025-01-17 Yves Mercier       Fix "Toggle all On/Off" included as an entity
 * 2.18       2025-01-18 Yves Mercier       Add support for siren entity
 * 2.20       2025-02-28 Enis Hoca          Added discovery debug logging; entity type filter and name search in discoveryPage
+* 2.21       2026-04-03 Dan Ogorchock      Added 'menu: "Integrations"' to definition to allow app to appear under the 2.5.x Integrations menu section
 */
 
 definition(
@@ -51,7 +52,8 @@ definition(
     importUrl: "https://raw.githubusercontent.com/ymerj/HE-HA-control/main/haDeviceBridgeConfiguration.groovy",
     iconUrl: "",
     iconX2Url: "",
-    iconX3Url: "")
+    iconX3Url: "",
+    menu: "Integrations")
 
 preferences
 {

--- a/packageManifest.json
+++ b/packageManifest.json
@@ -1,7 +1,7 @@
 {
   "packageName": "HE-HA-control",
   "author": "ymerj",
-  "version": "2.20",
+  "version": "2.21",
   "minimumHEVersion": "2.1.9",
   "dateReleased": "2021-03-19",
   "drivers": [


### PR DESCRIPTION
This will allow the HADB Configuration App to appear in Hubitat's new "Integrations" menu section in the web GUI (v2.5.x), as opposed to the generic "Apps" section.  Since HADB is all about integrating with HA, it seems like a reasonable change to me.  Earlier versions of Hubitat platform will simply ignore this new field (verified by running the updated 2.21 version on Hubitat platform 2.4.4.156.)